### PR TITLE
fix logger error

### DIFF
--- a/delegates.rb
+++ b/delegates.rb
@@ -138,6 +138,8 @@ class CustomDelegate
   end
 
   def fetch(url, headers)
+    logger = Java::edu.illinois.library.cantaloupe.script.Logger
+
     request = Net::HTTP::Get.new(url)
     request['Authorization'] = headers['Authorization'] unless headers['Authorization'].nil?
     logger.debug("REQUEST IS: #{request}")


### PR DESCRIPTION
Fixes this error that was created by my previous PR: 
```
Caused by: org.jruby.exceptions.NameError: (NameError) undefined local variable or method `logger' for #<CustomDelegate:0x1258b050>
	at RUBY.fetch(<script>:143)
```
