### PR TITLE
Feature/DR-1741 improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Updated
+- Update properties to return cached content immediately, if available. (DR-1741)
 
 ### Added
 - Added new type handling for tif requests. (DR-1678)

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -354,7 +354,7 @@ cache.server.purge_missing = true
 # If true, the source image will be confirmed to exist before a cached copy
 # is returned. If false, the cached copy will be returned without checking.
 # Resolving first is safer but slower.
-cache.server.resolve_first = true
+cache.server.resolve_first = false
 
 # !! Enables the cache worker, which periodically purges invalid cache
 # items in the background.


### PR DESCRIPTION
Switched Cantaloupe.Properties to use the aggressive method to see if it improves performance, according to https://cantaloupe-project.github.io/manual/5.0/caching.html#Source%20Cache

> Modes of Operation
The source and derivative caches can be configured to operate in one of two ways:

>**Conservative (cache.server.resolve_first = true)**
Source images are looked up and verified to exist before cached representations are returned. This precludes returning a cached representation when the underlying resource no longer exists, but also impairs response times by a variable amount, depending on the source.

> **Aggressive (cache.server.resolve_first = false)**
> Cached content is returned immediately, if available. This is faster, but inconsistency can develop between the source and the cache if the former is not static.
