### PR TITLE
Feature/DR-1764 fix f derivative cutting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## Fixed
+- Fixed bug with cutting f derivatives. (DR-1764)
+
 ## [0.1.1] - 2022-03-24
 
 ### Updated

--- a/delegates.rb
+++ b/delegates.rb
@@ -98,6 +98,7 @@ class CustomDelegate
 
   def derivative_type(size)
     longest_side = size["width"] > size["height"] ? size["width"] : size["height"]
+    puts "longest_side is #{longest_side}"
     case
       when (longest_side <= 100)
         "b"

--- a/delegates.rb
+++ b/delegates.rb
@@ -98,7 +98,6 @@ class CustomDelegate
 
   def derivative_type(size)
     longest_side = size["width"] > size["height"] ? size["width"] : size["height"]
-    puts "longest_side is #{longest_side}"
     case
       when (longest_side <= 100)
         "b"

--- a/nginx-configs/image_server_to_iiif.js
+++ b/nginx-configs/image_server_to_iiif.js
@@ -37,6 +37,8 @@ function mapImageServerToIIIF(request, response) {
   
   if (imageType == 'g' || imageType == 'j' || imageType == 's' || imageType == 'tif') {
     urlSegment = "full";
+  } else if (imageType == 'f') {
+    urlSegment = "," + dimension;
   } else {
     urlSegment = "!" + dimension + "," + dimension;
   }


### PR DESCRIPTION
Removed width from image api size params for f derivatives. 

From the IIIF v2 documentation:
```
,h | The image or region should be scaled so that its height is exactly equal to h, and the width will be a calculated value that maintains the aspect ratio of the extracted region.
-- | --
```


