### PR TITLE
DR-1838 fix info.json endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed info.json endpoint by using full_res rights logic. (DR-1838)
 
 ## [0.1.2] - 2022-04-01
 

--- a/delegates.rb
+++ b/delegates.rb
@@ -83,12 +83,11 @@ class CustomDelegate
   #
   def authorize(options = {})
     logger = Java::edu.illinois.library.cantaloupe.script.Logger
-   
     # full_res_file_access = ['10.128.99.55','10.128.1.167','10.224.6.10','10.128.99.167','10.128.98.50','10.224.6.26','10.224.6.35','172.16.1.94', '66.234.38.35']
     #'65.88.88.115'
     logger.debug("CONTEXT HASH: #{context}")
     logger.debug("REQUEST URI: #{context['request_uri']}")
-    type = derivative_type(context['resulting_size'])
+    type = context['request_uri'].include?("info.json") ? "full_res" : derivative_type(context['resulting_size'])
     logger.debug("TYPE: #{type}")
     rights = get_rights(context['identifier'], context['client_ip'])
     allowed = returns_rights?(rights) && is_not_restricted?(rights, type)


### PR DESCRIPTION
We need to use the IIIF image information endpoint for deep zoom in DC but I did not factor in the syntax of this endpoint when developing the rights aware logic (the logic requires a size param that the info endpoint does not use).  Since deep zoom will be using full res images, I felt it made sense to use the full_res rights restrictions for the image information endpoint.