### PR TITLE
[DR-1925] Update to cantaloupe to reduce logger instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed logger calls to use already created logger. (DR-1925)
+- Changed call to API to not be curl command but instead use basic net http. (DR-1925)
+
 ## [0.1.4] - 2022-05-13
 
 ### Added


### PR DESCRIPTION
Wondering if we can get away with using the logger already created instead of creating a bunch of new ones. Very loggers might mean less memory used. Maybe. 

Also wanted to try using native net http for calls to API to see if maybe something was happening with the curl requests. And this keeps it purely ruby. 