### PR TITLE
[DR-2041] No more default filepath. 404 instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed response for filepath to serve no default image when an image is not found. (DR-2041)
+
 ## [0.1.5] - 2022-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This uses Docker to locally to make it as easy as possible for developers to ins
 1.  `cp .env.example .env` (and fill in .env with credentials)
 2.  Optional: To work locally on the shim, edit `nginx-configs/image_server_to_iiif.js` and comment out line 44 and comment in line 47. (NB: Make sure to revert these changes for deployment.)
 3.  `docker-compose build`
+4.  `docker-compose up`
 4.  Test in a browser: http://localhost:8182/iiif/2/anything/full/full/0/default.jpg
 5.  Test shim in a browser: http://localhost:8080/index.php?id=anything&t=f
 

--- a/delegates.rb
+++ b/delegates.rb
@@ -262,13 +262,16 @@ class CustomDelegate
     end
     
     path = nil
-    
     if not uuid.nil?
       uuid =~ /(....)(....)\-(....)\-(....)\-(....)\-(....)(....)(..)../
       path = "/ifs/prod/repo/#{uuid[0..1]}/#{$1}/#{$2}/#{$3}/#{$4}/#{$5}/#{$6}/#{$7}/#{$8}/#{uuid}"
     end
     
-    path
+    if path.nil? && default_image_path.present?
+      default_image_path
+    else
+      path
+    end
   end
 
   ##

--- a/delegates.rb
+++ b/delegates.rb
@@ -262,15 +262,13 @@ class CustomDelegate
     end
     
     path = nil
+    
     if not uuid.nil?
       uuid =~ /(....)(....)\-(....)\-(....)\-(....)\-(....)(....)(..)../
       path = "/ifs/prod/repo/#{uuid[0..1]}/#{$1}/#{$2}/#{$3}/#{$4}/#{$5}/#{$6}/#{$7}/#{$8}/#{uuid}"
     end
-    if path.nil? 
-      default_image_path != nil ? default_image_path : "/ifs/prod/repo/FF/FF02/CD3C/93C7/11DD/A1C2/8CF9/9956/CD/FF02CD3C-93C7-11DD-A1C2-8CF99956CD08"
-    else
-      path
-    end
+    
+    path
   end
 
   ##


### PR DESCRIPTION
## Jira Tickets ##
[Default to 404 for no valid image.](https://jira.nypl.org/browse/DR-2041)

## Things Done ##
- Changed default filepath to return nil instead of an image if no image found. 

## How to Test ##
- Go to any fake image id url. Should respond with 404 instead of a boy scout image. 