### PR TITLE
DR 2419 upgrade canteloupe version to 5 x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tmp/
 local-imagecache/
 secrets.rb
 cantaloupe/
+*.swp
+*.swo

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     graphicsmagick \
     imagemagick \
-		ffmpeg \
-		maven \
-		libopenjp2-tools \
-		redis-server \
+    ffmpeg \
+    maven \
+    libopenjp2-tools \
+    redis-server \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /cantaloupe
 
-# Copy Cantaloupe war
-COPY cantaloupe-4.1.9.war .
+# Copy Cantaloupe jar
+COPY cantaloupe-5.0.5.jar .
 
 # Copy JDBC driver
 COPY mysql-connector-java-8.0.27.jar .
@@ -24,4 +24,4 @@ COPY cantaloupe.properties .
 COPY delegates.rb .
 COPY secrets.rb .
 
-CMD java -cp ./mysql-connector-java-8.0.27.jar:./cantaloupe-4.1.9.war -Dcantaloupe.config=./cantaloupe.properties -Xmx2g edu.illinois.library.cantaloupe.StandaloneEntry
+CMD java -cp ./mysql-connector-java-8.0.27.jar:./cantaloupe-5.0.5.jar -Dcantaloupe.config=./cantaloupe.properties -Xmx2g edu.illinois.library.cantaloupe.StandaloneEntry

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -20,7 +20,6 @@ http.port = 8182
 
 # !! Configures the HTTPS server. (Standalone mode only.)
 https.enabled = false
-#https.enabled = true
 https.host = 0.0.0.0
 https.port = 8183
 
@@ -206,7 +205,6 @@ processor.selection_strategy = ManualSelectionStrategy
 # Fall back to this processor for any formats not assigned above.
 #processor.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
-#processor.ManualSelectionStrategy.fallback = GraphicsMagickProcessor
 processor.ManualSelectionStrategy.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.xpm =
 

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -203,7 +203,6 @@ processor.selection_strategy = ManualSelectionStrategy
 #processor.webp = ImageMagickProcessor
 
 # Fall back to this processor for any formats not assigned above.
-#processor.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
 processor.ManualSelectionStrategy.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.xpm =

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -19,14 +19,15 @@ http.host = 0.0.0.0
 http.port = 8182
 
 # !! Configures the HTTPS server. (Standalone mode only.)
-https.enabled = true
+https.enabled = false
+#https.enabled = true
 https.host = 0.0.0.0
 https.port = 8183
 
 # !! Available values are `JKS` and `PKCS12`. (Standalone mode only.)
 https.key_store_type = JKS
 https.key_store_password = myPassword
-https.key_store_path = /path/to/keystore.jks
+#https.key_store_path = /path/to/keystore.jks
 https.key_password = myPassword
 
 # !! Constrains the size of the web server's thread pool. Leave blank to
@@ -173,12 +174,17 @@ FilesystemSource.BasicLookupStrategy.path_suffix =
 # Processor Selection
 #----------------------------------------
 
+# * If set to `AutomaticSelectionStrategy`, a "best" available processor
+#   will be selected per-request based on formats and installed
+#   dependencies.
+# * If set to `ManualSelectionStrategy`, a processor will be chosen based
+#   on the rest of the keys in this section.
 processor.selection_strategy = ManualSelectionStrategy
 
-# Image processors to use for various source formats. Available values are
-# `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
-# `KakaduDemoProcessor`, `KakaduNativeProcessor`, `OpenJpegProcessor`,
-# `JaiProcessor`, `PdfBoxProcessor`, and `FfmpegProcessor`.
+# Built-in processors are `Java2dProcessor`, TurboJpegProcessor`,
+# `KakaduNativeProcessor`, `OpenJpegProcessor`, `GrokProcessor`,`JaiProcessor`,
+# `PdfBoxProcessor`, and `FfmpegProcessor`.
+# Some of these have third-party dependencies and won't work out-of-the-box.
 
 # These extension-specific definitions are optional.
 #processor.avi = FfmpegProcessor
@@ -200,7 +206,8 @@ processor.selection_strategy = ManualSelectionStrategy
 # Fall back to this processor for any formats not assigned above.
 #processor.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
-processor.ManualSelectionStrategy.fallback = GraphicsMagickProcessor
+#processor.ManualSelectionStrategy.fallback = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.xpm =
 
 #----------------------------------------

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -17,20 +17,22 @@ temp_pathname = tmp/
 http.enabled = true
 http.host = 0.0.0.0
 http.port = 8182
-http.http2.enabled = false
 
 # !! Configures the HTTPS server. (Standalone mode only.)
 https.enabled = true
 https.host = 0.0.0.0
 https.port = 8183
-# Secure HTTP/2 requires Java 9 or later.
-https.http2.enabled = false
 
 # !! Available values are `JKS` and `PKCS12`. (Standalone mode only.)
 https.key_store_type = JKS
 https.key_store_password = myPassword
 https.key_store_path = /path/to/keystore.jks
 https.key_password = myPassword
+
+# !! Constrains the size of the web server's thread pool. Leave blank to
+# use the defaults.
+http.min_threads =
+http.max_threads =
 
 # !! Maximum size of the HTTP(S) request queue. Leave blank to use the
 # default.
@@ -53,6 +55,24 @@ slash_substitute =
 # response. Set to 0 for no maximum.
 max_pixels = 400000000
 
+# A meta-identifier is a superset of an identifier that includes other
+# information like a page number and/or scale constraint. A meta-identifier
+# transformer transforms a meta-identifier to and from a string in a URI
+# path component.
+# Available transformers include `StandardMetaIdentifierTransformer` and
+# `DelegateMetaIdentifierTransformer`. See the user manual for more
+# information about meta-identifiers and these options.
+meta_identifier.transformer = StandardMetaIdentifierTransformer
+
+# Character sequence that separates the components of a meta-identifier in
+# the identifier portion of a URI.
+meta_identifier.transformer.StandardMetaIdentifierTransformer.delimiter = ;
+
+# If true, HTTP >= 400-level responses are logged at WARN and ERROR level.
+# This may result in multiple log statements for the same error, but it may
+# also help diagnose errors that have evaded logging.
+log_error_responses = false
+
 # Errors will also be logged to the error log (if enabled).
 print_stack_trace_on_error_pages = true
 
@@ -69,10 +89,6 @@ delegate_script.enabled = true
 # then the current working directory.
 delegate_script.pathname = delegates.rb
 
-# Enables the invocation cache, which caches method invocations and return
-# values in memory. See the user manual for more information.
-delegate_script.cache.enabled = false
-
 ###########################################################################
 # ENDPOINTS
 ###########################################################################
@@ -88,10 +104,8 @@ endpoint.iiif.1.enabled = false
 # Enables the IIIF Image API 2.x endpoint, at /iiif/2.
 endpoint.iiif.2.enabled = true
 
-# Controls the response Content-Disposition header for images. Allowed
-# values are `inline`, `attachment`, and `none`. This can be overridden
-# using the ?response-content-disposition query argument.
-endpoint.iiif.content_disposition = inline
+# Enables the IIIF Image API 3.x endpoint, at /iiif/3.
+endpoint.iiif.3.enabled = true
 
 # Minimum size that will be used in info.json `sizes` keys.
 endpoint.iiif.min_size = 64
@@ -102,7 +116,7 @@ endpoint.iiif.min_tile_size = 512
 
 # If true, requests for sizes other than those contained in an information
 # response will be denied.
-endpoint.iiif.2.restrict_to_sizes = false
+endpoint.iiif.restrict_to_sizes = false
 
 # Enables the Control Panel, at /admin.
 endpoint.admin.enabled = true
@@ -115,6 +129,11 @@ endpoint.api.enabled = false
 # HTTP Basic credentials to access the HTTP API.
 endpoint.api.username =
 endpoint.api.secret =
+
+# If true, sources and caches will be checked, resulting in a more robust
+# but slower health check. Set this to false if these services already have
+# their own health checks.
+endpoint.health.dependency_check = false
 
 ###########################################################################
 # SOURCES
@@ -182,6 +201,7 @@ processor.selection_strategy = ManualSelectionStrategy
 #processor.fallback = Java2dProcessor
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
 processor.ManualSelectionStrategy.fallback = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.xpm =
 
 #----------------------------------------
 # Global Processor Configuration
@@ -221,16 +241,13 @@ processor.background_color = white
 processor.downscale_filter = bicubic
 processor.upscale_filter = bicubic
 
+# If true, images are downscaled in a linear color space, which is more
+# accurate. This only works with mono-resolution (non-pyramidal) images. It
+# also may impair performance.
+processor.downscale_linear = false
+
 # Intensity of an unsharp mask from 0 to 1.
 processor.sharpen = 0
-
-# Attempts to copy source image metadata (EXIF, IPTC, XMP) into derivative
-# images. (This is not foolproof; see the user manual.)
-processor.metadata.preserve = false
-
-# Whether to auto-rotate images using the EXIF `Orientation` field.
-# The check for this field can impair performance slightly.
-processor.metadata.respect_orientation = false
 
 # Progressive JPEGs are usually more compact.
 processor.jpg.progressive = true
@@ -257,6 +274,7 @@ processor.imageio.png.reader =
 processor.imageio.png.writer =
 processor.imageio.tif.reader =
 processor.imageio.tif.writer =
+processor.imageio.xpm.reader =
 
 #----------------------------------------
 # FfmpegProcessor
@@ -267,36 +285,30 @@ processor.imageio.tif.writer =
 FfmpegProcessor.path_to_binaries =
 
 #----------------------------------------
-# GraphicsMagickProcessor
-#----------------------------------------
-
-# !! Optional absolute path of the directory containing the GraphicsMagick
-# binary. Overrides the PATH.
-GraphicsMagickProcessor.path_to_binaries = /usr/bin
-
-#----------------------------------------
-# ImageMagickProcessor
-#----------------------------------------
-
-# !! Optional absolute path of the directory containing the ImageMagick
-# binary. Overrides the PATH.
-ImageMagickProcessor.path_to_binaries =
-
-#----------------------------------------
-# KakaduDemoProcessor
-#----------------------------------------
-
-# Optional absolute path of the directory containing kdu_expand.
-# Overrides the PATH.
-KakaduDemoProcessor.path_to_binaries =
-
-#----------------------------------------
 # OpenJpegProcessor
 #----------------------------------------
 
 # Optional absolute path of the directory containing opj_decompress.
 # Overrides the PATH.
 OpenJpegProcessor.path_to_binaries = /usr/bin
+
+#----------------------------------------
+# GrokProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing grk_decompress.
+# Overrides the PATH.
+GrokProcessor.path_to_binaries =
+
+#----------------------------------------
+# PdfBoxProcessor
+#----------------------------------------
+
+# The following will enable disk to be used as well as memory during
+# PDF loading in PdfBoxProcessor.  If `max_memory_bytes` is -1 it
+# will use unlimited memory.
+processor.pdf.scratch_file_enabled = false
+processor.pdf.max_memory_bytes = -1
 
 ###########################################################################
 # CLIENT-SIDE CACHING
@@ -427,6 +439,9 @@ JdbcCache.info_table = info_cache
 # https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 S3Cache.endpoint =
 
+# !! AWS region. Only needed for AWS endpoints.
+S3Cache.region =
+
 # !! Credentials for your AWS account.
 # See: http://aws.amazon.com/security-credentials
 # Note that this info can be obtained from elsewhere rather than setting it
@@ -439,10 +454,6 @@ S3Cache.bucket.name =
 
 # !! String that will be prefixed to object keys.
 S3Cache.object_key_prefix =
-
-# !! Maximum number of concurrent HTTP connections to AWS. Leave blank to
-# use the default.
-S3Cache.max_connections =
 
 #----------------------------------------
 # AzureStorageCache
@@ -474,7 +485,7 @@ RedisCache.database = 0
 ###########################################################################
 
 # Whether to enable overlays.
-overlays.enabled = false
+overlays.BasicStrategy.enabled = false
 
 # Controls how overlays are configured. `BasicStrategy` will use the
 # `overlays.BasicStrategy.*` keys in this section. `ScriptStrategy` will
@@ -536,13 +547,6 @@ overlays.BasicStrategy.output_width_threshold = 400
 overlays.BasicStrategy.output_height_threshold = 300
 
 ###########################################################################
-# REDACTIONS
-###########################################################################
-
-# See the user manual for information about how redactions work.
-redaction.enabled = false
-
-###########################################################################
 # LOGGING
 ###########################################################################
 
@@ -554,8 +558,12 @@ redaction.enabled = false
 log.application.level = trace
 
 log.application.ConsoleAppender.enabled = true
+log.application.ConsoleAppender.logstash.enabled = false
+
+log.application.FileAppender.logstash.enabled = false
 
 log.application.RollingFileAppender.enabled = true
+log.application.RollingFileAppender.logstash.enabled = false
 log.application.RollingFileAppender.pathname = log/cantaloupe-application.log
 log.application.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = log/cantaloupe-application-%d{yyyy-MM-dd}.log
@@ -575,7 +583,10 @@ log.application.SyslogAppender.facility = LOCAL0
 # Application log messages with a severity of WARN or greater can be copied
 # into a dedicated error log, which may make them easier to spot.
 
+log.error.FileAppender.logstash.enabled = false
+
 log.error.RollingFileAppender.enabled = true
+log.error.RollingFileAppender.logstash.enabled = false
 log.error.RollingFileAppender.pathname = log/cantaloupe-error.log
 log.error.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = log/cantaloupe-error-%d{yyyy-MM-dd}.log


### PR DESCRIPTION
## JIRA ticket:
- [Upgrade Cantaloupe](https://jira.nypl.org/browse/DR-2419)

## Things Done:
- Upgraded the canteloupe server from v4.1.9 to v5.0.5 (latest)
- Followed the upgrade steps
- Disabled ssl at the server level. The assumption is that this is not needed.
- Replaced GraphicsMagick with Java2dProcessor as the fallback image processor. This will definitely need to be tested!


## How to test:
- In development: rebuild the canteloupe server docker container and test images and the shim locally as per the README
- In qa: test images and the shim. We'll also need to get acceptance testing set up. Something about cutting image derivatives as well?

## Questions:
- The new delegates.rb script methods required for this version are still unimplemented. Do we need to implement these?