### PR TITLE
DR-2472 mount a local image repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is configured to read source images from S3.
 This uses Docker to locally to make it as easy as possible for developers to install.
 
 1.  `cp .env.example .env` (and fill in .env with credentials)
-2.  Optional: To work locally on the shim, edit `nginx-configs/image_server_to_iiif.js` and comment out line 44 and comment in line 47. (NB: Make sure to revert these changes for deployment.)
+2.  Optional: To work locally on the shim, edit `nginx-configs/image_server_to_iiif.js` and comment out line 54 and comment in line 58. (NB: Make sure to revert these changes for deployment.)
 3.  `docker-compose build`
 4.  `docker-compose up`
 4.  Test in a browser: http://localhost:8182/iiif/2/53926/full/full/0/default.jpg

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This branch looks for source images in the `./images` directory, which is mounte
 
 Source and derivative images are cached in `./cache`, which is mounted into the container at `/ifs/prod/iiif-imagecache`.
 
+You can download images from the production repo and put them into `./repo` using the correct directory structure. If you then connect your local canteloupe instance to the qa filestore, as long as the added images exist in that database, the local shim should be able to serve them. This is useful for testing images that don't render.
+
 ## Git Workflow
 
 Our branches (in order or stability are):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - './images:/var/www/images.nypl.org'
       - './cache:/ifs/prod/iiif-imagecache'
+      - './repo:/ifs/prod/repo'
     ports:
       - '8182:8182'
 


### PR DESCRIPTION
This PR doesn't relate specifically to closing DR-2472 but adds some capability for us to be able to dev test images that don't render properly on less accessible environments.

## How to Test ##
- Update `nginx-configs/image_server_to_iiif.js` for local shim use as mentioned in the README.
- Configure DB_URL, DB_UNAME, and DB_PASS in .env to connect to the production filestore database
- Download an image from the production image repo to your local (scp works fine, or ask for one that I have downloaded already). 
- Note the image's filepath as you're doing this. You can also find the path by attempting to render the image using the shim locally as long as you're connected to the qa filestore database from local. The filepath will be in the stack trace shown in the browser.
- Create the image's filepath directory in your local `repo` folder with `mkdir -p <path_without_filename>` (for example: `mkdir -p /B1/B116/AD22/0697/11E2/9D4C/8488/957D/67`). Then, copy the downloaded image into the created directory.
- Rebuild your containers and run them. You should now be able to use the local shim to view the downloaded image.