### PR TITLE
DR 2578 render regressed images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Rendered regressed images (DR-2578)
+
 ### Upgraded
 - Upgraded nginx to 1.25
 - Upgraded Canteloupe to 5.0.5 (DR-2419)

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -55,6 +55,8 @@ slash_substitute =
 # response. Set to 0 for no maximum.
 max_pixels = 400000000
 
+max_scale = 1000.0
+
 # A meta-identifier is a superset of an identifier that includes other
 # information like a page number and/or scale constraint. A meta-identifier
 # transformer transforms a meta-identifier to and from a string in a URI


### PR DESCRIPTION
## JIRA ticket:
- [IIIF regression: Some images that are displaying on Production are not displaying on QA](https://jira.nypl.org/browse/DR-2578)

## Things Done:
- Set a max_scale value in canteloupe.properties to a high value that we shouldn't need to reach (previously, we had not used this and it was effectively infinite -- apparently the upgrade has a default of 1.0 or 100%)

## How to test:
- Download one or more of the w-types for the images listed in the ticket with scp to your local and set them up in your local repo folder as described in https://github.com/NYPL/cantaloupe/pull/42
- Connect to the VPN and rebuild your containers. You'll probably also need to to add a new line 174 of `true` to the `authorize` method return value of [deletages.rb](https://github.com/NYPL/cantaloupe/blob/55002640e3d4c859a53b0dbfafe35fc6e4f28aa3/delegates.rb#L159) if not on premises to have rights to view some of the images. Do this before building the containers.
- Bring up the app locally and navigate to one of the images mentioned that you set up in your local image repo (for example: http://localhost:8080/index.php?id=827387&t=q). It should now render rather than throwing a scaling error.