### PR TITLE
[DR-2570] Force use of https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Rendered regressed images (DR-2578)
+- Forced use of https API urls. (DR-2570)
 
 ### Upgraded
 - Upgraded nginx to 1.25

--- a/delegates.rb
+++ b/delegates.rb
@@ -234,31 +234,26 @@ class CustomDelegate
   def fetch(path, ip)
     require 'net/http'
     require 'uri'
-    # logger = Java::edu.illinois.library.cantaloupe.delegate.Logger
-    #.logger.debug("API URL IS: #{api_url(path)}")
-    # logger.debug("IPS ARE: #{ip}")
-
+    require 'json'
+    
     uri = URI.parse(api_url(path))
-    request = Net::HTTP::Post.new(uri)
-    request.body = `'{"ips":["#{ip}"]}'`
-    request.set_content_type("application/json")
-    request["Accept"] = "application/json"
-    request["Authorization"] = "Token token=#{Secret.api_configuration[:auth_token]}"
-    
-    req_options = {
-      use_ssl: uri.scheme == "https",
-    }
 
-    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-      http.request(request)
-    end
-    
-    # logger.debug("RESPONSE IS: #{response}")
+    request = Net::HTTP::Post.new(uri)
+    request.body = '{"ips":["#{ip}"]}'
+    request.content_type = 'application/json'
+    request['Accept'] = 'application/json'
+    request['Authorization'] = "Token token=#{Secret.api_configuration[:auth_token]}"
+
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.use_ssl = true if uri.scheme == 'https' # which it should be, as I've hard-coded the api url to https.
+
+    response = http.request(request)
+
     return response.body
   end
 
   def api_url(path)
-    "#{Secret.api_configuration[:api_url]}/api/v2/#{path}"
+    "https://api.repo.nypl.org/api/v2/#{path}"
   end
 
   ##

--- a/delegates.rb
+++ b/delegates.rb
@@ -245,7 +245,7 @@ class CustomDelegate
     request['Authorization'] = "Token token=#{Secret.api_configuration[:auth_token]}"
 
     http = Net::HTTP.new(uri.hostname, uri.port)
-    http.use_ssl = true if uri.scheme == 'https' # which it should be, as I've hard-coded the api url to https.
+    http.use_ssl = true
 
     response = http.request(request)
 

--- a/secrets.rb.sample
+++ b/secrets.rb.sample
@@ -10,7 +10,6 @@ class Secret
 
   def self.api_configuration
     {
-      api_url: 'https://api.repo.nypl.org',
       auth_token: 'yourAPIKeyHere'
     }
   end


### PR DESCRIPTION
## JIRA ticket:
- [Force use of https for Repo API](https://jira.nypl.org/browse/DR-2570)

## Things Done:
- Given that the api url is not a big secret, and given that I don't want to require setting it as a server variable (or risk that having it set somewhere is causing issues), I opted to hard-code the API url as https in the method in delegates.rb
- Cleaned up the fetch method in delegates.rb
- Updated sample secrets file

## How to test:
- Test with any image. Should still work as normal. 
- We'll deploy to dev to double check with ops that it is not making any odd http calls. I'm not 100% sure there's not something we're missing. 