### PR TITLE
DR 2761 fix f derivative identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed identification of f derivative types (DR-2761)
+
 ## [0.2.0] - 2024-01-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ You can download images from the production repo and put them into `./repo` usin
 - Create the image's filepath directory in your local `repo` folder with `mkdir -p <path_without_filename>` (for example: `mkdir -p /B1/B116/AD22/0697/11E2/9D4C/8488/957D/67`). Then, copy the downloaded image into the created directory.
 - Rebuild your containers and run them. You should now be able to use the local shim to view the downloaded image.
 
+## Running Unit Tests
+- Install jruby on your local (homebrew is fine on mac)
+- Do `jruby test/<test_file_name>` to run tests
+
 ## Git Workflow
 
 Our branches (in order or stability are):

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Source and derivative images are cached in `./cache`, which is mounted into the 
 
 You can download images from the production repo and put them into `./repo` using the correct directory structure. If you then connect your local canteloupe instance to the qa filestore, as long as the added images exist in that database, the local shim should be able to serve them. This is useful for testing images that don't render.
 
+## Testing Images Locally
+- Update `nginx-configs/image_server_to_iiif.js` for local shim use as mentioned above.
+- Configure DB_URL, DB_UNAME, and DB_PASS in .env to connect to the qa or production filestore database
+- Download an image from the production image repo to your local.
+- Note the image's filepath as you're doing this. You can also find the path by attempting to render the image using the shim locally as long as you're connected to a remote filestore database from local. The filepath will be in the stack trace shown in the browser.
+- Create the image's filepath directory in your local `repo` folder with `mkdir -p <path_without_filename>` (for example: `mkdir -p /B1/B116/AD22/0697/11E2/9D4C/8488/957D/67`). Then, copy the downloaded image into the created directory.
+- Rebuild your containers and run them. You should now be able to use the local shim to view the downloaded image.
+
 ## Git Workflow
 
 Our branches (in order or stability are):

--- a/test/delegates_test.rb
+++ b/test/delegates_test.rb
@@ -1,0 +1,57 @@
+# delegates_test.rb
+require 'minitest/autorun'
+require_relative '../delegates'
+
+class YourClassTest < Minitest::Test
+  def test_derivative_type
+    delegates = CustomDelegate.new
+
+    size = { 'height' => 100, 'width' => 90 }
+    assert_equal 'b', delegates.derivative_type(size)
+
+    size = { 'height' => 45, 'width' => 50 }
+    assert_equal 'b', delegates.derivative_type(size)
+
+    size = { 'height' => 140, 'width' => 200 }
+    assert_equal 'f', delegates.derivative_type(size)
+
+    size = { 'height' => 139, 'width' => 101 }
+    assert_equal 'f', delegates.derivative_type(size)
+
+    size = { 'height' => 145, 'width' => 150 }
+    assert_equal 't', delegates.derivative_type(size)
+
+    size = { 'height' => 149, 'width' => 101 }
+    assert_equal 't', delegates.derivative_type(size)
+
+    size = { 'height' => 300, 'width' => 200 }
+    assert_equal 'r', delegates.derivative_type(size)
+
+    size = { 'height' => 250, 'width' => 299 }
+    assert_equal 'r', delegates.derivative_type(size)
+
+    size = { 'height' => 480, 'width' => 760 }
+    assert_equal 'w', delegates.derivative_type(size)
+
+    size = { 'height' => 520, 'width' => 758 }
+    assert_equal 'w', delegates.derivative_type(size)
+
+    size = { 'height' => 1600, 'width' => 1200 }
+    assert_equal 'q', delegates.derivative_type(size)
+
+    size = { 'height' => 249, 'width' => 1597 }
+    assert_equal 'q', delegates.derivative_type(size)
+
+    size = { 'height' => 2247, 'width' => 2560 }
+    assert_equal 'v', delegates.derivative_type(size)
+
+    size = { 'height' => 2400, 'width' => 1800 }
+    assert_equal 'v', delegates.derivative_type(size)
+
+    size = { 'height' => 3000, 'width' => 2000 }
+    assert_equal 'full_res', delegates.derivative_type(size)
+
+    size = { 'height' => 2561, 'width' => 2345 }
+    assert_equal 'full_res', delegates.derivative_type(size)
+  end
+end


### PR DESCRIPTION
## JIRA ticket:
- [longest side values exceed expected values for given file types](https://jira.nypl.org/browse/DR-2761)

## Things Done:
- Small refactor of the derivative type switch statement
- Made the condition for identifying `f` rely on the height rather than the longest side
- Added some (very rudimentary) unit tests
- Updated the documentation

## How to test:
- Install jruby on your local, then run the unit tests with `jtest/delegates_test.rb`
- cd to Projects and copy a problematic `f` file to your local with scp. For me, it was something like `scp <user>@172.16.1.103:/ifs/prod/repo/55/5509/E474/93B2/11DD/9FB8/7CE6/9956/CD/5509E474-93B2-11DD-9FB8-7CE69956CD08 5509E474-93B2-11DD-9FB8-7CE69956CD08`. This is assuming you have a username/password combo on the qa IIIF servers.
- cd to `cantaloupe/repo` and make the new directory on your local mounted mock filestore with `mkdir -p 55/5509/E474/93B2/11DD/9FB8/7CE6/9956/CD`
- finally, move the image there with `cd ../..` and `mv 5509E474-93B2-11DD-9FB8-7CE69956CD08 cantaloupe/repo/55/5509/E474/93B2/11DD/9FB8/7CE6/9956/CD/5509E474-93B2-11DD-9FB8-7CE69956CD08`
- Enable the remote QA database for DB_URL, DB_UNAME, and DB_PASS in your .env
- Modify the shim as described in the README for local development
- Rebuild the docker containers and bring them up.
- go to http://localhost:8080/index.php?id=1104775&t=f. Lo and behold, the image renders whereas it does not on qa or prod.
