### PR TITLE
DR-2777 fix QA admin panel

### DIFF
--- a/cantaloupe.properties.dev
+++ b/cantaloupe.properties.dev
@@ -1,13 +1,5 @@
 ###########################################################################
-# Sample Cantaloupe configuration file
-#
-# Copy this file to `cantaloupe.properties` and edit as desired.
-#
-# Keys may change from version to version. See the "Upgrading" section of
-# the website.
-#
-# Most changes will take effect without restarting. Those that won't are
-# marked with "!!".
+# Cantaloupe configuration file for QA environment
 ###########################################################################
 
 # !! Leave blank to use the JVM default temporary directory.

--- a/cantaloupe.properties.dev
+++ b/cantaloupe.properties.dev
@@ -44,7 +44,7 @@ http.accept_queue_limit =
 # Base URI to use for internal links, such as Link headers and JSON-LD
 # @id values, in a reverse-proxy context. This should only be used when
 # X-Forwarded-* headers cannot be used instead. (See the user manual.)
-base_uri = https://dev-iiif.nypl.org
+base_uri = https://qa-iiif.nypl.org
 
 # Normally, slashes in a URI path component must be percent-encoded as
 # "%2F". If your proxy is not able to pass these through without decoding,

--- a/cantaloupe.properties.prod
+++ b/cantaloupe.properties.prod
@@ -1,13 +1,5 @@
 ###########################################################################
-# Sample Cantaloupe configuration file
-#
-# Copy this file to `cantaloupe.properties` and edit as desired.
-#
-# Keys may change from version to version. See the "Upgrading" section of
-# the website.
-#
-# Most changes will take effect without restarting. Those that won't are
-# marked with "!!".
+# Cantaloupe configuration file for production environment
 ###########################################################################
 
 # !! Leave blank to use the JVM default temporary directory.


### PR DESCRIPTION
There is no "dev" IIIF environment, we just have QA and prod. The "cataloupe.properties.dev" file is used in QA, and needs this base_uri set to QA for assets to work.
