### PR TITLE
DR 2892 reduce logging level (everywhere)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Bypass RepoAPI rights call for DC Facelift homepage featured images (DR-2901)
+- Reduced logging level from trace to info (DR-2892)
+
 ## [0.2.3] - 2024-03-28
 
 ### Changed
 - Bypass RepoAPI rights call for DC Facelift homepage swimlane images (DR-2873)
-- Bypass RepoAPI rights call for DC Facelift homepage featured images (DR-2901)
 
 ## [0.2.2] - 2024-03-20
 

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -561,7 +561,7 @@ overlays.BasicStrategy.output_height_threshold = 300
 #----------------------------------------
 
 # `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
-log.application.level = trace
+log.application.level = info
 
 log.application.ConsoleAppender.enabled = true
 log.application.ConsoleAppender.logstash.enabled = false

--- a/cantaloupe.properties.dev
+++ b/cantaloupe.properties.dev
@@ -557,7 +557,7 @@ overlays.BasicStrategy.output_height_threshold = 300
 #----------------------------------------
 
 # `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
-log.application.level = trace
+log.application.level = info
 
 log.application.ConsoleAppender.enabled = true
 log.application.ConsoleAppender.logstash.enabled = false

--- a/cantaloupe.properties.prod
+++ b/cantaloupe.properties.prod
@@ -557,7 +557,7 @@ overlays.BasicStrategy.output_height_threshold = 300
 #----------------------------------------
 
 # `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
-log.application.level = trace
+log.application.level = info
 
 log.application.ConsoleAppender.enabled = true
 log.application.ConsoleAppender.logstash.enabled = false


### PR DESCRIPTION
## Ticket:

- [Reduce logging on IIIF/Cantaloupe](https://jira.nypl.org/browse/DR-2892).

## Things Done

- Reduced the logging level in every environment from `trace` to `info`

## How to Test

- Rebuild your container and run the application. The log should be a lot less noisy and should print only log statements at the level `INFO` and above, (including `WARN` and `ERROR`).