### PR TITLE
Remove restart from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
   db:
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
-    restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password
     volumes:


### PR DESCRIPTION
## How to Test
- rebuild your containers with `docker-compose build`
- bring your containers up with `docker-compose up`
- stop all the containers with ctl+c or `docker-compose down`
- Stop your docker service or exit docker desktop and restart it.
- No containers from the current project should be running