### PR TITLE
v0.2.5 backmerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [Unreleased]
-
-## [0.2.4] - 2024-04-04
+## [0.2.5] - 2024-04-23
 
 ### Added
 - Serve robots.txt to discourage web crawlers (DR-2929)
+
+## [0.2.4] - 2024-04-04
 
 ### Changed
 - Bypass RepoAPI rights call for DC Facelift homepage featured images (DR-2901)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
 ## [0.2.5] - 2024-04-23
 
 ### Added


### PR DESCRIPTION
This backmerges the v0.2.5 release (https://github.com/NYPL/cantaloupe/pull/73)