### PR TITLE
DR 2934 add forked repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cantaloupe-project"]
+	path = cantaloupe-project
+	url = https://github.com/NYPL/cantaloupe-project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Changed
+- Fork cantaloupe project and include it as a submodule in NYPL cantaloupe (DR-2934)
+
 ## [0.2.4] - 2024-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ You will rarely need to build the underlying cantaloupe project from source. Thi
 
 ### Building on a Mac
 
-* v5.0.5 (the currently used base) is built using a Java 11 runtime. To install this locally, use `brew install openjdk@11`
+* NYPL is maintaining a forked version of https://github.com/cantaloupe-project/cantaloupe that lives at https://github.com/NYPL/cantaloupe-project. This forked repository is included in the current project as a submodule in /cantaloupe-project.
+* v5.0.5 (the currently used base version) is built using a Java 11 runtime. To install this locally, use `brew install openjdk@11`
 * Once Java 11 is installed, you'll want to set it as the default. Find the installation directory with `brew --prefix openjdk@11`
 * You may need to symlink the new installation with `sudo ln -sfn <path_to_installation_directory>/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk`
 * Open your shell config file (for a bash shell, this'll be `~/.bashrc` or `~/.bash_profile`, for zshell, it's `~/.zshrc`)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ It is configured to read source images from S3.
 
 ## Building
 
-You will rarely need to build the underlying cantaloupe project from source. This will only be necessary when a version upgrade is being undertaken or code changes to the source are necessary.
+You will rarely need to build the underlying cantaloupe project from source. This will only be necessary when a version upgrade is being undertaken or code changes to the source are necessary. NYPL is maintaining a forked version of https://github.com/cantaloupe-project/cantaloupe that lives at https://github.com/NYPL/cantaloupe-project. This forked repository is included in the current project as a submodule in /cantaloupe-project.
 
 ### Building on a Mac
 
-* NYPL is maintaining a forked version of https://github.com/cantaloupe-project/cantaloupe that lives at https://github.com/NYPL/cantaloupe-project. This forked repository is included in the current project as a submodule in /cantaloupe-project.
 * v5.0.5 (the currently used base version) is built using a Java 11 runtime. To install this locally, use `brew install openjdk@11`
 * Once Java 11 is installed, you'll want to set it as the default. Find the installation directory with `brew --prefix openjdk@11`
 * You may need to symlink the new installation with `sudo ln -sfn <path_to_installation_directory>/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,31 @@
 NYPL's implementation of the Cantaloupe [IIIF image server](https://medusa-project.github.io/cantaloupe/).
 It is configured to read source images from S3.
 
+## Building
+
+You will rarely need to build the underlying cantaloupe project from source. This will only be necessary when a version upgrade is being undertaken or code changes to the source are necessary.
+
+### Building on a Mac
+
+* v5.0.5 (the currently used base) is built using a Java 11 runtime. To install this locally, use `brew install openjdk@11`
+* Once Java 11 is installed, you'll want to set it as the default. Find the installation directory with `brew --prefix openjdk@11`
+* You may need to symlink the new installation with `sudo ln -sfn <path_to_installation_directory>/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk`
+* Open your shell config file (for a bash shell, this'll be `~/.bashrc` or `~/.bash_profile`, for zshell, it's `~/.zshrc`)
+* Add the following: `export JAVA_HOME=<path_to_installation_directory>/openjdk@11` (for example, `export JAVA_HOME=/opt/homebrew/opt/openjdk@11`
+* Also add `export PATH=$JAVA_HOME/bin:$PATH`
+* Save and close the config file, then source it with `source <config_file>` (for example `source ~/.zshrc`)
+* Make sure your local environment sees Java 11 as the default version with `java -version`. You should see something like this:
+```
+openjdk version "11.0.23" 2024-04-16
+OpenJDK Runtime Environment Homebrew (build 11.0.23+0)
+OpenJDK 64-Bit Server VM Homebrew (build 11.0.23+0, mixed mode)
+```
+* Install the Maven build management tool with `brew install mvn` and then make sure the system recognizes it with `which mvn`
+* `cd` into `cantaloupe-project/` and check out the current build branch (v5.0.5-nypl-implementation) if the submodule is not already at the head of that branch.
+* try to build the project with `mvn clean package -DskipTests`. If there are no bugs in the code, it should build successfully. The output files should be in `cantaloupe-project/target/`.
+* Copy the newly built .jar file out of `target/` and into the root of the NYPL/cantaloupe.git project. Make sure it is named `cantaloupe-5.0.5.jar`. It should overwrite the existing jarfile.
+* The next time you build the NYPL cantaloupe project with `docker-compose build`, the new server code will become effective.
+
 ## Installing
 
 This uses Docker to locally to make it as easy as possible for developers to install.


### PR DESCRIPTION
## JIRA ticket:
- [Fork cantaloupe project and include it as a submodule in NYPL cantaloupe](https://jira.nypl.org/browse/DR-2934)

## Things Done:
- Forked the cantaloupe project and added it as a submodule to this repository
- Added steps for building the server to the README

## How to test:
- Read the readme changes and see if they make sense. Improvements are very welcome.
- If you're really ambitious, you can follow the steps and build the project.

## To do:
- As we learn more about maintainting the forked repo, the maintenance steps involved should be added to the readme.
- See who else needs to be added to https://github.com/NYPL/cantaloupe-project/settings/access